### PR TITLE
chore: remove package for polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3",
-    "paragonie/random_compat": "^2.0"
+    "php": ">=7.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The dependency of `paragonie/random_compat` doesn't seem useful anymore.

I guess it was useful for PHP less than 7.

See https://github.com/paragonie/random_compat/blob/master/lib/random.php#L47-L49