### PR TITLE
ci: add PHP versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,6 +19,8 @@ jobs:
                     - '8.0'
                     - '8.1'
                     - '8.2'
+                    - '8.3'
+                    - '8.4'
 
         steps:
             -   name: Checkout code


### PR DESCRIPTION
This PR adds on the CI:
- PHP 8.3
- PHP 8.4